### PR TITLE
:alien: 同步 API 0.2.1 版本的接口

### DIFF
--- a/nonebot_plugin_bilichat/request_api/base.py
+++ b/nonebot_plugin_bilichat/request_api/base.py
@@ -9,7 +9,7 @@ from nonebot_plugin_bilichat.lib.tools import shorten_long_items
 from nonebot_plugin_bilichat.model.exception import RequestError
 from nonebot_plugin_bilichat.model.request_api import Account, Content, Dynamic, LiveRoom, Note, SearchUp, VersionInfo
 
-MINIMUM_API_VERSION = Version("0.1.3")
+MINIMUM_API_VERSION = Version("0.2.1")
 
 
 class RequestAPI:
@@ -78,12 +78,11 @@ class RequestAPI:
     async def account_web_all(self) -> list[Account]:
         return [Account(cookies={}, **acc) for acc in (await self._get("/account/web_account")).json()]
 
-    async def account_web_creat(self, uid: int, cookies: list[dict] | dict, note: Note) -> Account:
+    async def account_web_creat(self, cookies: list[dict] | dict, note: Note) -> Account:
         return Account.model_validate(
             (
                 await self._post(
                     "/account/web_account/create",
-                    params={"uid": str(uid)},
                     json={"cookies": cookies, "note": note.model_dump()},
                 )
             ).json()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "nonebot-plugin-bilichat"
 
-version = "6.0.4"
+version = "6.0.5"
 
 description = "全功能的 bilibili 内容解析器及订阅器"
 authors = [


### PR DESCRIPTION
## Summary by Sourcery

更新最低 API 版本至 0.2.1 并从 `account_web_creat` 方法中移除 uid 参数。版本升级至 6.0.5。

新特性：
- 支持 API 版本 0.2.1。

增强：
- 从 `account_web_creat` 方法中移除 `uid` 参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the minimum API version to 0.2.1 and remove the uid parameter from the account_web_creat method. Bump version to 6.0.5.

New Features:
- Support API version 0.2.1.

Enhancements:
- Remove the `uid` parameter from the `account_web_creat` method.

</details>