### PR TITLE
:bug:修复推送下播通知时没有直播时长

### DIFF
--- a/nonebot_plugin_bilichat/subscribe/fetch_and_push.py
+++ b/nonebot_plugin_bilichat/subscribe/fetch_and_push.py
@@ -88,8 +88,7 @@ async def live():
         # 第一次获取, 仅更新状态
         if up.live_status == -1:
             up.live_status = live.live_status
-            if live.live_status == 1:
-                up.live_time = live.live_time
+            up.live_time = live.live_time
             continue
         # 正在直播, live.live_status == 1
         if live.live_status == 1:
@@ -124,14 +123,14 @@ async def live():
                 up_info.uname = up.name  # 更新up名字
                 up_name = up_info.nickname or up_info.uname
                 live_time = (
-                    Text(f"\n本次直播时长 {calc_time_total(time.time() - up.live_time)}")
+                    Text(f"\n本次直播时长 {calc_time_total(time.time() - up.live_time)}\n直播时间由 bilibili 返回，不代表真实直播时间，仅供参考")
                     if up.live_time > 1500000000
                     else Text("")
                 )
                 msg = UniMessage([Text(f"{up_name} 下播了"), live_time])
                 await user.target.send(msg)
         up.live_status = live.live_status
-        up.live_time = live.live_time
+        up.live_time = live.live_time if up.live_time <= live.live_time else 0
 
 
 def set_subs_job():

--- a/nonebot_plugin_bilichat/subscribe/fetch_and_push.py
+++ b/nonebot_plugin_bilichat/subscribe/fetch_and_push.py
@@ -88,7 +88,6 @@ async def live():
         # 第一次获取, 仅更新状态
         if up.live_status == -1:
             up.live_status = live.live_status
-            up.live_time = live.live_time
             continue
         # 正在直播, live.live_status == 1
         if live.live_status == 1:
@@ -130,7 +129,7 @@ async def live():
                 msg = UniMessage([Text(f"{up_name} 下播了"), live_time])
                 await user.target.send(msg)
         up.live_status = live.live_status
-        up.live_time = live.live_time if up.live_time <= live.live_time else 0
+        up.live_time = live.live_time or up.live_time
 
 
 def set_subs_job():

--- a/nonebot_plugin_bilichat/subscribe/fetch_and_push.py
+++ b/nonebot_plugin_bilichat/subscribe/fetch_and_push.py
@@ -88,6 +88,8 @@ async def live():
         # 第一次获取, 仅更新状态
         if up.live_status == -1:
             up.live_status = live.live_status
+            if live.live_status == 1:
+                up.live_time = live.live_time
             continue
         # 正在直播, live.live_status == 1
         if live.live_status == 1:
@@ -122,13 +124,14 @@ async def live():
                 up_info.uname = up.name  # 更新up名字
                 up_name = up_info.nickname or up_info.uname
                 live_time = (
-                    Text(f"\n本次直播时长 {calc_time_total(time.time() - live.live_time)}")
-                    if live.live_time > 1500000000
+                    Text(f"\n本次直播时长 {calc_time_total(time.time() - up.live_time)}")
+                    if up.live_time > 1500000000
                     else Text("")
                 )
                 msg = UniMessage([Text(f"{up_name} 下播了"), live_time])
                 await user.target.send(msg)
         up.live_status = live.live_status
+        up.live_time = live.live_time
 
 
 def set_subs_job():

--- a/nonebot_plugin_bilichat/subscribe/status.py
+++ b/nonebot_plugin_bilichat/subscribe/status.py
@@ -19,8 +19,8 @@ class UPStatus(BaseModel):
     """最新的动态id"""
     live_status: int = -1
     """直播状态, 0: 未开播, 1: 开播, 2: 轮播"""
-    live_time: int = -1
-    """上次直播时间"""
+    live_time: int = 0
+    """直播开始时间"""
 
     @property
     def users(self) -> list[UserInfo]:

--- a/nonebot_plugin_bilichat/subscribe/status.py
+++ b/nonebot_plugin_bilichat/subscribe/status.py
@@ -19,6 +19,8 @@ class UPStatus(BaseModel):
     """最新的动态id"""
     live_status: int = -1
     """直播状态, 0: 未开播, 1: 开播, 2: 轮播"""
+    live_time: int = -1
+    """上次直播时间"""
 
     @property
     def users(self) -> list[UserInfo]:


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修复了离线推送通知不显示直播时长的问题。通过在直播开始时记录直播开始时间，并在发送离线通知时根据记录的开始时间计算时长来解决此问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the bug where the live duration was not displayed in the offline notification when pushing offline notifications by recording the live start time when the live stream starts and calculating the duration based on the recorded start time when sending the offline notification

</details>