### PR TITLE
:pencil: 添加 WebUI 启动日志输出

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ _✨ 多功能的 B 站视频解析工具 ✨_
 
 您可以参考 [配置文件模板](https://github.com/Well2333/nonebot-plugin-bilichat/blob/v6.0.5/nonebot_plugin_bilichat/static/config.yaml) 来了解配置项及其含义。
 
+## 🌐 WebUI
+
+本项目提供了一个 WebUI 用于实时查看及部分热修改配置文件，启动时将会在日志中输出 WebUI 的访问地址，例如: `BiliChat WebUI 已启动 --> http://127.0.0.1:40094/bilichatwebui`
+
 ## 🔌 API
 
 > 从 6.0.0 版本开始，`bilibili` 请求已迁移至 [bilichat-request](https://github.com/Well2333/bilichat-request) 模块，并改为 API 通讯方式。这一改进带来了多项优化：支持一对多的负载均衡、提升 Cookies 管理效率，并有效应对更严格的风控措施。同时，原本需要浏览器操作（如截图）的任务被移至远程服务器处理，从而减轻本地机器的内存压力。

--- a/nonebot_plugin_bilichat/api/__init__.py
+++ b/nonebot_plugin_bilichat/api/__init__.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.staticfiles import StaticFiles
+from nonebot.log import logger
 
-from nonebot_plugin_bilichat.config import STATIC_DIR, ConfigCTX
+from nonebot_plugin_bilichat.config import STATIC_DIR, ConfigCTX, nonebot_config
 
 from .base import app
 from .config import router as config_router
@@ -30,3 +31,5 @@ app.mount(
     StaticFiles(directory=STATIC_DIR.joinpath("html"), html=True),
     name="bilichat_webui",
 )
+
+logger.success(f"BiliChat WebUI 已启动 --> http://127.0.0.1:{nonebot_config.port}/{ConfigCTX.get().webui.api_path}")


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

为插件添加一个 WebUI，用于实时查看和热重载配置文件，并在启动时将访问 URL 打印到日志中。

新特性：
- 引入一个 WebUI，用于实时查看和热重载配置文件。

文档：
- 添加了关于新 WebUI 的文档，包括如何通过打印的日志消息访问它。

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

为插件添加一个 WebUI，用于实时查看和热重载配置文件，并在启动时将访问 URL 打印到日志中。

新特性：
- 引入一个 WebUI，用于实时查看和热重载配置文件。

增强功能：
- 启动时记录 WebUI 访问 URL。

文档：
- 添加了新 WebUI 的文档，包括如何通过打印的日志消息访问它。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adds a WebUI to the plugin for real-time viewing and hot-reloading of configuration files, and prints the access URL to the logs on startup.

New Features:
- Introduces a WebUI for real-time viewing and hot-reloading of configuration files.

Enhancements:
- Logs the WebUI access URL upon startup.

Documentation:
- Adds documentation for the new WebUI, including how to access it via the printed log message.

</details>

</details>