### PR TITLE
:bug: 新增 alconna 发送消息的 fallback 开关

### DIFF
--- a/nonebot_plugin_bilichat/base_content_parsing.py
+++ b/nonebot_plugin_bilichat/base_content_parsing.py
@@ -123,4 +123,4 @@ async def content_info(origin_msg: UniMsg, state: T_State):
         logger.error(e)
         msgs.append(Text(f"{e.type}: {e.message}"))
 
-    receipt = await msgs.send()
+    receipt = await msgs.send(fallback=ConfigCTX.get().nonebot.fallback)

--- a/nonebot_plugin_bilichat/command/functions.py
+++ b/nonebot_plugin_bilichat/command/functions.py
@@ -31,7 +31,7 @@ async def check_dynamic_v11(target: MsgTarget, uid: Message = CommandArg()):
         latest_dyn = max(dyns, key=lambda x: x.dyn_id)
         BilichatCD.record_cd(session_id=target.id, content_id=str(latest_dyn.dyn_id))
         if dyn := await api.content_dynamic(latest_dyn.dyn_id, ConfigCTX.get().api.browser_shot_quality):
-            await UniMessage(Image(raw=dyn.img_bytes)).send(target=target)
+            await UniMessage(Image(raw=dyn.img_bytes)).send(target=target, fallback=ConfigCTX.get().nonebot.fallback)
 
 
 bili_fetch_content = bilichat.command("fetch", aliases=set(ConfigCTX.get().nonebot.cmd_fetch), block=True)

--- a/nonebot_plugin_bilichat/command/login.py
+++ b/nonebot_plugin_bilichat/command/login.py
@@ -58,7 +58,8 @@ async def bili_login_handle():
 @bili_login_qrcode.handle()
 async def bili_qrcode_login(target: MsgTarget):
     await bili_login_qrcode.send(
-        "由于通过 Bot 扫码获取的 cookies 缺失一部分数据, 有效期可能较短且无法实时更新, 因此此方法将不再维护, 建议使用 cookiescloud 登录。"
+        "由于通过 Bot 扫码获取的 cookies 缺失一部分数据, 有效期可能较短且无法实时更新, 因此此方法将不再维护, 建议使用 cookiescloud 登录。",
+        fallback=ConfigCTX.get().nonebot.fallback,
     )
     async with AsyncClient(
         headers={
@@ -97,7 +98,7 @@ async def bili_qrcode_login(target: MsgTarget):
         img_data = BytesIO()
         img.save(img_data)
         await UniMessage([Text("请在 120s 内使用 bilibili 客户端扫描二维码登录"), Image(raw=img_data.getvalue())]).send(
-            target=target
+            target=target, fallback=ConfigCTX.get().nonebot.fallback
         )
 
         # 轮询登录状态

--- a/nonebot_plugin_bilichat/model/config.py
+++ b/nonebot_plugin_bilichat/model/config.py
@@ -35,9 +35,9 @@ class NoneBotConfig(BaseModel):
         json_schema_extra={"ui:options": {"disabled": True}},
     )
     fallback: bool = Field(
-        default=False,
+        default=True,
         title="启用发送失败回退",
-        description="启用 Alconna 的发送失败回退机制, 可能会导致刷屏BUG",
+        description="是否启用 Alconna 的发送失败回退机制",
         json_schema_extra={"ui:options": {"disabled": True}},
     )
     enable_self: bool = Field(

--- a/nonebot_plugin_bilichat/model/config.py
+++ b/nonebot_plugin_bilichat/model/config.py
@@ -34,6 +34,12 @@ class NoneBotConfig(BaseModel):
         description="是否拦截事件(防止其他插件二次解析)",
         json_schema_extra={"ui:options": {"disabled": True}},
     )
+    fallback: bool = Field(
+        default=False,
+        title="启用发送失败回退",
+        description="启用 Alconna 的发送失败回退机制, 可能会导致刷屏BUG",
+        json_schema_extra={"ui:options": {"disabled": True}},
+    )
     enable_self: bool = Field(
         default=False,
         title="响应自身的消息",

--- a/nonebot_plugin_bilichat/subscribe/fetch_and_push.py
+++ b/nonebot_plugin_bilichat/subscribe/fetch_and_push.py
@@ -91,53 +91,55 @@ async def live():
         if up.name != live.uname:
             up.set_name(live.uname)
         logger.debug(f"[Live] UP {up.name}({up.uid}) 直播状态: {live.live_status} 历史状态: {up.live_status}")
-        # 第一次获取, 仅更新状态
-        if up.live_status == -1:
-            up.live_status = live.live_status
-            continue
-        # 正在直播, live.live_status == 1
-        if live.live_status == 1:
-            # 开播通知, up.live_status != 1
-            if up.live_status != 1:
-                cover = (await AsyncClient().get(live.cover_from_user)).content
-                live_cover = Image(raw=cover)
+        try:
+            # 第一次获取, 仅更新状态
+            if up.live_status == -1:
+                up.live_status = live.live_status
+                continue
+            # 正在直播, live.live_status == 1
+            if live.live_status == 1:
+                # 开播通知, up.live_status != 1
+                if up.live_status != 1:
+                    cover = (await AsyncClient().get(live.cover_from_user)).content
+                    live_cover = Image(raw=cover)
+                    for user in up.users:
+                        if user.subscribes_dict[up.uid].live == PushType.IGNORE:
+                            continue
+                        logger.info(f"[Live] 推送 UP {up.name}({up.uid}) 开播给用户 {user.id}")
+                        up_info = user.subscribes_dict[up.uid]
+                        up_info.uname = up.name  # 更新up名字
+                        up_name = up_info.nickname or up_info.uname
+                        at_all = AtAll() if user.subscribes_dict[up.uid].live == PushType.AT_ALL else Text("")
+                        msg = UniMessage(
+                            [
+                                at_all,
+                                Text(f"{up_name} 开播了: {live.title}\n"),
+                                live_cover,
+                                Text(f"\nhttps://live.bilibili.com/{live.room_id}"),
+                            ]
+                        )
+                        await user.target.send(msg, fallback=ConfigCTX.get().nonebot.fallback)
+            # 下播通知, up.live_status == 1 且 live.live_status != 1
+            elif up.live_status == 1:
                 for user in up.users:
                     if user.subscribes_dict[up.uid].live == PushType.IGNORE:
                         continue
-                    logger.info(f"[Live] 推送 UP {up.name}({up.uid}) 开播给用户 {user.id}")
+                    logger.info(f"[Live] 推送 UP {up.name}({up.uid}) 下播给用户 {user.id}")
                     up_info = user.subscribes_dict[up.uid]
                     up_info.uname = up.name  # 更新up名字
                     up_name = up_info.nickname or up_info.uname
-                    at_all = AtAll() if user.subscribes_dict[up.uid].live == PushType.AT_ALL else Text("")
-                    msg = UniMessage(
-                        [
-                            at_all,
-                            Text(f"{up_name} 开播了: {live.title}\n"),
-                            live_cover,
-                            Text(f"\nhttps://live.bilibili.com/{live.room_id}"),
-                        ]
+                    live_time = (
+                        Text(
+                            f"\n本次直播时长 {calc_time_total(time.time() - up.live_time)}\n直播时间由 bilibili 返回, 不代表真实直播时间, 仅供参考"
+                        )
+                        if up.live_time > 1500000000
+                        else Text("")
                     )
+                    msg = UniMessage([Text(f"{up_name} 下播了"), live_time])
                     await user.target.send(msg, fallback=ConfigCTX.get().nonebot.fallback)
-        # 下播通知, up.live_status == 1 且 live.live_status != 1
-        elif up.live_status == 1:
-            for user in up.users:
-                if user.subscribes_dict[up.uid].live == PushType.IGNORE:
-                    continue
-                logger.info(f"[Live] 推送 UP {up.name}({up.uid}) 下播给用户 {user.id}")
-                up_info = user.subscribes_dict[up.uid]
-                up_info.uname = up.name  # 更新up名字
-                up_name = up_info.nickname or up_info.uname
-                live_time = (
-                    Text(
-                        f"\n本次直播时长 {calc_time_total(time.time() - up.live_time)}\n直播时间由 bilibili 返回, 不代表真实直播时间, 仅供参考"
-                    )
-                    if up.live_time > 1500000000
-                    else Text("")
-                )
-                msg = UniMessage([Text(f"{up_name} 下播了"), live_time])
-                await user.target.send(msg, fallback=ConfigCTX.get().nonebot.fallback)
-        up.live_status = live.live_status
-        up.live_time = live.live_time or up.live_time
+        finally:
+            up.live_status = live.live_status
+            up.live_time = live.live_time or up.live_time
 
 
 def set_subs_job():

--- a/nonebot_plugin_bilichat/subscribe/fetch_and_push.py
+++ b/nonebot_plugin_bilichat/subscribe/fetch_and_push.py
@@ -62,7 +62,7 @@ async def dynamic():
                     msg = UniMessage([at_all, Text(f"{up_name} 发布了新动态\n"), dyn_img, Text(f"\n{content.b23}")])
                     target = user.target
                     logger.debug(f"target: {target}")
-                    await user.target.send(msg)
+                    await user.target.send(msg, fallback=ConfigCTX.get().nonebot.fallback)
         except Exception as e:
             capture_exception(e)
             logger.exception(e)
@@ -117,7 +117,7 @@ async def live():
                             Text(f"\nhttps://live.bilibili.com/{live.room_id}"),
                         ]
                     )
-                    await user.target.send(msg)
+                    await user.target.send(msg, fallback=ConfigCTX.get().nonebot.fallback)
         # 下播通知, up.live_status == 1 且 live.live_status != 1
         elif up.live_status == 1:
             for user in up.users:
@@ -135,7 +135,7 @@ async def live():
                     else Text("")
                 )
                 msg = UniMessage([Text(f"{up_name} 下播了"), live_time])
-                await user.target.send(msg)
+                await user.target.send(msg, fallback=ConfigCTX.get().nonebot.fallback)
         up.live_status = live.live_status
         up.live_time = live.live_time or up.live_time
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加了一个通过 Alconna 发送消息的备用机制，可以通过 NoneBot 配置中的新 `fallback` 选项进行配置。 此选项在主要消息发送方法失败时启用备用策略。 此外，`fallback` 参数已添加到所有 `send` 调用中。

增强功能：
- 为通过 Alconna 发送消息添加了备用机制。
- 将 fallback 参数传递给所有 send 调用。

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加了一个通过 Alconna 发送消息的备用机制，可以通过 NoneBot 配置中的新 `fallback` 选项进行配置。 如果主要消息发送方法失败，此选项启用备用策略。 将 fallback 参数传递给所有发送调用。

增强功能：
- 添加了一个通过 Alconna 发送消息的备用机制。
- 将 fallback 参数传递给所有发送调用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adds a fallback mechanism for sending messages via Alconna, configurable via a new `fallback` option in the NoneBot configuration. This option enables a fallback strategy if the primary message sending method fails. Passes the fallback parameter to all send calls.

Enhancements:
- Adds a fallback mechanism for sending messages via Alconna.
- Passes the fallback parameter to all send calls.

</details>

</details>