### PR TITLE
:alien: 升级依赖项bilichat-request至0.4.0

### DIFF
--- a/nonebot_plugin_bilichat/model/request_api.py
+++ b/nonebot_plugin_bilichat/model/request_api.py
@@ -1,7 +1,7 @@
 import base64
 from datetime import datetime
 from enum import Enum
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -18,16 +18,16 @@ class VersionInfo(BaseModel):
 
 
 class Note(BaseModel):
-    create_time: str
+    create_time: str | None = None
     """Create Time"""
     source: str
     """Source"""
 
 
 class Account(BaseModel):
-    cookies: dict[str, Any]
-    note: Note
     uid: int
+    type: str
+    note: Note
 
     def __str__(self) -> str:
         return f"{self.uid}({self.note.source})"

--- a/nonebot_plugin_bilichat/request_api/__init__.py
+++ b/nonebot_plugin_bilichat/request_api/__init__.py
@@ -1,5 +1,4 @@
 import random
-from contextlib import suppress
 
 from nonebot import get_driver
 from nonebot.log import logger

--- a/nonebot_plugin_bilichat/request_api/base.py
+++ b/nonebot_plugin_bilichat/request_api/base.py
@@ -9,7 +9,7 @@ from nonebot_plugin_bilichat.lib.tools import shorten_long_items
 from nonebot_plugin_bilichat.model.exception import APIError, RequestError
 from nonebot_plugin_bilichat.model.request_api import Account, Content, Dynamic, LiveRoom, Note, SearchUp, VersionInfo
 
-MINIMUM_API_VERSION = Version("0.2.4")
+MINIMUM_API_VERSION = Version("0.4.0")
 MAX_CONSECUTIVE_ERRORS = 10  # 连续错误阈值
 
 
@@ -151,7 +151,7 @@ class RequestAPI:
         )
 
     async def account_web_all(self) -> list[Account]:
-        return [Account(cookies={}, **acc) for acc in (await self._get("/account/web_account")).json()]
+        return [Account(**acc) for acc in (await self._get("/account/web_account")).json()]
 
     async def account_web_creat(self, cookies: list[dict] | dict, note: Note) -> Account:
         return Account.model_validate(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "nonebot-plugin-bilichat"
 
-version = "6.3.0"
+version = "6.3.1"
 
 description = "全功能的 bilibili 内容解析器及订阅器"
 authors = [
@@ -30,7 +30,7 @@ readme = "README.md"
 license = { text = "AGPL3.0" }
 [project.optional-dependencies]
 api = [
-    "bilichat-request>=0.3.4",
+    "bilichat-request>=0.4.0",
 ]
 
 [build-system]


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将 bilichat-request 依赖升级到 v0.4.0，调整最低 API 版本，更新数据模型，并增加插件版本。

增强功能：
- 将最低 API 版本要求提升至 0.4.0
- 使 Note.create_time 成为可选字段，默认值为 None
- 在 Account 模型中添加 type 字段，并移除其 cookies 属性
- 更新 account_web_all 以在没有 cookies 的情况下实例化 Account
- 将插件版本从 6.3.0 提升至 6.3.1

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade bilichat-request dependency to v0.4.0, adjust minimum API version, update data models, and bump plugin version.

Enhancements:
- Bump minimum API version requirement to 0.4.0
- Make Note.create_time optional with a default None
- Add type field to Account model and remove its cookies attribute
- Update account_web_all to instantiate Account without cookies
- Bump plugin version from 6.3.0 to 6.3.1

</details>