### PR TITLE
:alien: 兼容 alconna 0.59.0+

### DIFF
--- a/nonebot_plugin_bilichat/base_content_parsing.py
+++ b/nonebot_plugin_bilichat/base_content_parsing.py
@@ -107,10 +107,8 @@ bilichat = on_message(
 
 
 @bilichat.handle()
-async def content_info(origin_msg: UniMsg, state: T_State):
+async def content_info(state: T_State):
     msgs = UniMessage()
-    reply = Reply(id=origin_msg.get_message_id())
-    msgs.append(reply)
     try:
         raw_cont: Content = state["_raw_cont_"]
         if raw_cont.type == "video":
@@ -136,4 +134,4 @@ async def content_info(origin_msg: UniMsg, state: T_State):
         logger.error(e)
         msgs.append(Text(f"{e.type}: {e.message}"))
 
-    receipt = await msgs.send(fallback=ConfigCTX.get().nonebot.fallback)
+    receipt = await msgs.send(fallback=ConfigCTX.get().nonebot.fallback, reply_to=True)


### PR DESCRIPTION
https://github.com/nonebot/plugin-alconna/releases/tag/v0.59.0

## Sourcery 总结

更新 `content_info` 处理器以匹配 Alconna 0.59.0+ 的变化，具体通过移除 `origin_msg` 参数、放弃手动 `Reply` 对象以及通过 `reply_to` 启用自动回复。

错误修复：
- 调整 `content_info` 处理器的签名和回复逻辑，使其与 Alconna 0.59.0+ 兼容

改进：
- 移除手动 `Reply` 创建，并在发送消息时使用 `reply_to` 标志

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update content_info handler to match Alconna 0.59.0+ changes by removing the origin_msg parameter, dropping the manual Reply object, and enabling automatic replies via reply_to.

Bug Fixes:
- Make content_info handler compatible with Alconna 0.59.0+ by adjusting its signature and reply logic

Enhancements:
- Remove manual Reply creation and use the reply_to flag when sending messages

</details>