### PR TITLE
fix: log spam caused by FinishedException raised in rule

### DIFF
--- a/nonebot_plugin_bilichat/base_content_parsing.py
+++ b/nonebot_plugin_bilichat/base_content_parsing.py
@@ -44,7 +44,7 @@ async def _bili_check(state: T_State, event: Event, bot: Bot, msg: UniMsg) -> bo
         api = get_request_api()
     except APIError:
         logger.error("无API可用, 跳过解析")
-        raise FinishedException from None
+        return False
     _msgs = msg.copy()
     if Reply in msg and (
         (ConfigCTX.get().nonebot.enable_self and str(event.get_user_id()) == str(bot.self_id)) or event.is_tome()


### PR DESCRIPTION

<img width="984" height="274" alt="image" src="https://github.com/user-attachments/assets/d47fc1aa-7186-4824-8155-6c217b842a72" />


## Sourcery 总结

错误修复：
- 在 `_bili_check` 的 `APIError` 处理器中，通过返回 `False` 而不是抛出 `FinishedException` 来防止日志刷屏

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent log spam by returning False instead of raising FinishedException in the APIError handler of _bili_check

</details>